### PR TITLE
Allow evaluate and page-number inside style, and remove @text-style from evaluate

### DIFF
--- a/src/examples/example1.obfl
+++ b/src/examples/example1.obfl
@@ -145,6 +145,12 @@
 					</tr>
 				</tbody>
 			</table>
+			<block id="a">
+				Evaluate within style: <style name="strong"><evaluate expression="(now &quot;yyyy-MM-dd HH:mm&quot;)"/></style>
+			</block>
+			<block>
+				Page number within style: <style name="strong"><page-number ref-id="a"/></style>
+			</block>
 		</sequence>
 		<sequence master="rear">
 			<block>This is part of a new sequence. Note that this sequence does not have an initial page number. Page numbering continues from the preceding section.</block>

--- a/src/obfl-specification.html
+++ b/src/obfl-specification.html
@@ -1139,14 +1139,12 @@ information.</p>
 <div class="sidebar">
 <dl>
   <dt>Usage</dt>
-    <dd class="markup">before, after, field, toc-entry, block, item</dd>
+    <dd class="markup">before, after, field, toc-entry, block, item, style</dd>
   <dt>Attributes</dt>
     <dd><dl>
         <dt>expression [required]</dt>
           <dd>A valid <a href="obfl-evaluation-language.html">OBFL Evaluation
             Language</a> expression.</dd>
-        <dt>text-style [optional]</dt>
-          <dd class="">A text style, e.g. emphasis or strong</dd>
       </dl>
     </dd>
   <dt>Content Model</dt>
@@ -1254,7 +1252,7 @@ element.</p>
 <div class="sidebar markup">
 <dl>
   <dt>Usage</dt>
-    <dd>before, after, toc-entry, block, item</dd>
+    <dd>before, after, toc-entry, block, item, style</dd>
   <dt>Attributes</dt>
     <dd><dl>
         <dt>ref-id [required]</dt>
@@ -1317,7 +1315,7 @@ emphasis or strong.</p>
       </dl>
     </dd>
   <dt>Content Model</dt>
-    <dd>text(), style, marker, br, anchor [0 or more]</dd>
+    <dd>text(), style, marker, br, anchor, evaluate, page-number [0 or more]</dd>
 </dl>
 </div>
 

--- a/src/validation/obfl.rng
+++ b/src/validation/obfl.rng
@@ -775,11 +775,6 @@
   </define>
   <define name="attlist-evaluate" combine="interleave">
     <attribute name="expression"/>
-    <optional>
-      <attribute name="text-style">
-        <data type="NMTOKEN"/>
-      </attribute>
-    </optional>
   </define>
   <define name="table-of-contents">
     <element name="table-of-contents">
@@ -1330,6 +1325,8 @@
           <ref name="marker"/>
           <ref name="br"/>
           <ref name="anchor"/>
+          <ref name="evaluate"/>
+          <ref name="page-number"/>
         </choice>
       </zeroOrMore>
     </element>


### PR DESCRIPTION
Fixes https://github.com/braillespecs/obfl/issues/44 and https://github.com/braillespecs/obfl/issues/63.